### PR TITLE
PropertyResolverPass: added to pass pipeline

### DIFF
--- a/src/casmi.cpp
+++ b/src/casmi.cpp
@@ -183,6 +183,7 @@ int main( int argc, const char* argv[] )
     pm.add< libcasm_fe::AttributionPass >();
     pm.add< libcasm_fe::SymbolRegistrationPass >();
     pm.add< libcasm_fe::SymbolResolverPass >();
+    pm.add< libcasm_fe::PropertyResolverPass >();
     pm.add< libcasm_fe::TypeInferencePass >();
     pm.add< libcasm_fe::TypeCheckPass >();
     pm.add< libcasm_fe::ConsistencyCheckPass >();


### PR DESCRIPTION
- adds the new `PropertyResolverPass` to the pass pipeine
- PR blocked by casm-lang/libcasm-fe#112
 