### PR TITLE
Output path command line option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ UPDATE_ROOT = ../../lib/stdhl
 
 include .cmake/config.mk
 
-ENV_FLAGS = CASM_ARG_PRE=--ast-exec-num
+ENV_FLAGS = CASM_ARG_PRE=--ast-exec
 ifeq ($(ENV_OSYS),Windows)
   ENV_FLAGS += CASM=$(OBJ)\\$(TARGET)
 else


### PR DESCRIPTION
- introduces a command line option `-o` (or `--output`) to specify an output path for the AST dump
- fixes numeric execution default command line option, which gets passed during the integration test
- depends on casm-lang/libcasm-fe#184
