### PR TITLE
SymbolicExecutionPass

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ on: [push]
 
 jobs:
   linux-x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         tool:
@@ -80,7 +80,7 @@ jobs:
         ./bash
 
   darwin-x86_64:
-    runs-on: macos-latest
+    runs-on: macos-10.15
     strategy:
       matrix:
         tool:
@@ -140,10 +140,10 @@ jobs:
         choco install ninja
         make ci-tools
     - name: Install
-      uses: pavpanchekha/setup-z3@1.2.2
+      uses: ppaulweber/github-action-setup-z3@bug/url_fix
       with:
-        version: 4.8.8
-        architecture: x64
+        version: 4.8.10
+        architecture: x64-win
     - name: Fetching
       env:
         ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -33,7 +33,7 @@ on:
 
 jobs:
   linux-x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         tool:
@@ -82,7 +82,7 @@ jobs:
         path: obj/bundle
 
   darwin-x86_64:
-    runs-on: macos-latest
+    runs-on: macos-10.15
     strategy:
       matrix:
         tool:

--- a/src/casmi.cpp
+++ b/src/casmi.cpp
@@ -143,6 +143,7 @@ int main( int argc, const char* argv[] )
     pm.add< libcasm_fe::AstDumpDotPass >();
     pm.add< libcasm_fe::AstDumpSourcePass >();
     pm.add< libcasm_fe::NumericExecutionPass >();
+    pm.add< libcasm_fe::SymbolicExecutionPass >();
 
     for( auto id : pm.passes() )
     {

--- a/src/casmi.cpp
+++ b/src/casmi.cpp
@@ -200,6 +200,13 @@ int main( int argc, const char* argv[] )
         // pass.setDumpUpdates( flag_dump_updates );
     } );
 
+    pm.set< libcasm_fe::SymbolicExecutionPass >( [&]( libcasm_fe::SymbolicExecutionPass& pass ) {
+        if( outputPath.size() != 0 )
+        {
+            pass.setOutputPath( outputPath.front() );
+        }
+    } );
+
     pm.set< libcasm_fe::AstDumpDotPass >( [&]( libcasm_fe::AstDumpDotPass& pass ) {
         if( outputPath.size() != 0 )
         {


### PR DESCRIPTION
This PR introduces the following changes:

* integrates the new symbolic/concolic execution into the interpreter application
* new command line flag `-s` to trigger symbolic execution which writes the TPTP trace to the `stdout` or by providing a `-o` to a TPTP specification output file
